### PR TITLE
Add GitHub action for cross-platform release builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,104 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            ext: ""
+          - os: macos-latest
+            ext: ""
+          - os: windows-latest
+            ext: .exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1.0.8
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-binary
+          path: target/release/format-date-for-irs${{ matrix.ext }}
+
+  create-release:
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Set timestamp
+        id: time
+        run: echo "timestamp=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: release-${{ steps.time.outputs.timestamp }}
+          release_name: Release ${{ steps.time.outputs.timestamp }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+
+  upload-assets:
+    needs: [build, create-release]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            ext: ""
+            label: linux
+          - os: macos-latest
+            ext: ""
+            label: macos
+          - os: windows-latest
+            ext: .exe
+            label: windows
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.os }}-binary
+          path: release
+      - name: Rename binary
+        run: mv release/format-date-for-irs${{ matrix.ext }} release/format-date-for-irs-${{ matrix.label }}${{ matrix.ext }}
+      - name: Upload asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: release/format-date-for-irs-${{ matrix.label }}${{ matrix.ext }}
+          asset_name: format-date-for-irs-${{ matrix.label }}${{ matrix.ext }}
+          asset_content_type: application/octet-stream
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v1.0.8
       with:
         toolchain: stable
         profile: minimal


### PR DESCRIPTION
## Summary
- set up a workflow that builds the binary on Windows, Linux, and macOS when `master` is pushed
- cache cargo directories for faster builds
- create a timestamped release and upload the compiled binaries
- use action matrix to download & upload each OS's binary
- enable release notes generation
- update actions versions to Node20-compatible releases

## Testing
- `cargo test` *(fails: could not connect to crates.io)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new automated workflow for building and releasing platform-specific binaries, with releases now including timestamped tags and downloadable assets for each operating system.
	- Updated the Rust build workflow to use a specific version of the Rust toolchain setup action for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->