### PR TITLE
Add doctests and unit tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,6 @@ pub fn parse_date(date: &str) -> Option<NaiveDate> {
 /// assert_eq!(formatted, "05/15/2024");
 /// ```
 pub fn format_date_for_irs(date: &NaiveDate) -> String {
-pub fn format_date_for_irs(date: &NaiveDate) -> String {
     let date = NaiveDate::from_ymd_opt(date.year(), date.month(), date.day()).unwrap();
     let date = date.format("%m/%d/%Y").to_string();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,16 @@ use std::time::Duration;
 use cli_clipboard::{ClipboardContext, ClipboardProvider};
 use chrono::{Datelike, NaiveDate,};
 
-/// Listens for clipboard changes
-/// On change it will check if the clipboard contains a date
-/// If it does, it will format the date for the IRS and copy it to the clipboard
+/// Listens for clipboard changes.
+///
+/// ```ignore
+/// use format_date_for_irs::check_clipboard;
+/// // gx todo: mock clipboard for reliable testing
+/// check_clipboard(); // this runs indefinitely
+/// ```
+///
+/// On change it will check if the clipboard contains a date.
+/// If it does, it will format the date for the IRS and copy it to the clipboard.
 pub fn check_clipboard()
 {
     let mut clipboard = ClipboardContext::new().unwrap();
@@ -23,9 +30,22 @@ pub fn check_clipboard()
     }
 }
 
-/// Parses a string into a date
-/// Returns None if the string is not a date, otherwise returns Some(date)
-fn parse_date(date: &str) -> Option<NaiveDate> {
+/// Parses a string into a date.
+///
+/// Returns `None` if the string does not match `mm/dd/yy`.
+///
+/// # Examples
+///
+/// ```
+/// use format_date_for_irs::parse_date;
+/// use chrono::NaiveDate;
+///
+/// let date = parse_date("01/02/21").unwrap();
+/// assert_eq!(date, NaiveDate::from_ymd_opt(2021, 1, 2).unwrap());
+/// ```
+///
+/// // gx todo: handle four-digit years
+pub fn parse_date(date: &str) -> Option<NaiveDate> {
     let date = date.trim();
 
     println!( "Scanned for date; found: {date:?}" );
@@ -44,14 +64,55 @@ fn parse_date(date: &str) -> Option<NaiveDate> {
     None
 }
 
-/// Formats a date for the IRS
-/// Date must be in the format mm/dd/yy
-/// Returns a string in the format mm/dd/yyyy
-fn format_date_for_irs(date: &NaiveDate) -> String {
+/// Formats a date for the IRS.
+///
+/// # Examples
+///
+/// ```
+/// use chrono::NaiveDate;
+/// use format_date_for_irs::format_date_for_irs;
+///
+/// let date = NaiveDate::from_ymd_opt(2021, 1, 2).unwrap();
+/// assert_eq!(format_date_for_irs(&date), "01/02/2021");
+/// ```
+///
+/// // gx todo: support other locales
+pub fn format_date_for_irs(date: &NaiveDate) -> String {
     let date = NaiveDate::from_ymd_opt(date.year(), date.month(), date.day()).unwrap();
     let date = date.format("%m/%d/%Y").to_string();
 
     println!("Formatted date: {date}");
 
     date
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    #[test]
+    fn parse_date_valid() {
+        let expected = NaiveDate::from_ymd_opt(2021, 1, 2).unwrap();
+        assert_eq!(parse_date("01/02/21"), Some(expected));
+    }
+
+    #[test]
+    fn parse_date_failure() {
+        assert!(parse_date("notadate").is_none());
+        assert!(parse_date("13/32/22").is_none());
+    }
+
+    #[test]
+    fn parse_date_trim() {
+        let trimmed = parse_date("01/02/21");
+        let spaced = parse_date(" 01/02/21 ");
+        assert_eq!(trimmed, spaced);
+    }
+
+    #[test]
+    fn format_date() {
+        let date = NaiveDate::from_ymd_opt(2021, 1, 2).unwrap();
+        assert_eq!(format_date_for_irs(&date), "01/02/2021");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,17 @@ use chrono::{Datelike, NaiveDate,};
 /// ```
 ///
 /// On change it will check if the clipboard contains a date.
-/// If it does, it will format the date for the IRS and copy it to the clipboard.
+/// Monitors the clipboard for date strings and reformats them for IRS compliance.
+///
+/// Continuously checks the clipboard for changes. If a new clipboard entry contains a date in `mm/dd/yy` format,
+/// it parses and reformats the date to `mm/dd/YYYY` and updates the clipboard with the formatted value.
+///
+/// # Examples
+///
+/// ```ignore
+/// // This function runs indefinitely and should be called from your main function.
+/// check_clipboard();
+/// ```
 pub fn check_clipboard()
 {
     let mut clipboard = ClipboardContext::new().unwrap();
@@ -44,7 +54,17 @@ pub fn check_clipboard()
 /// assert_eq!(date, NaiveDate::from_ymd_opt(2021, 1, 2).unwrap());
 /// ```
 ///
-/// // gx todo: handle four-digit years
+/// Attempts to parse a string as a date in `mm/dd/yy` format.
+///
+/// Trims leading and trailing whitespace from the input and tries to interpret it as a date using the `mm/dd/yy` format. Returns a `NaiveDate` if parsing is successful; otherwise, returns `None`.
+///
+/// # Examples
+///
+/// ```
+/// use chrono::NaiveDate;
+/// let date = parse_date(" 12/31/23 ");
+/// assert_eq!(date, Some(NaiveDate::from_ymd_opt(2023, 12, 31).unwrap()));
+/// ```
 pub fn parse_date(date: &str) -> Option<NaiveDate> {
     let date = date.trim();
 
@@ -76,7 +96,17 @@ pub fn parse_date(date: &str) -> Option<NaiveDate> {
 /// assert_eq!(format_date_for_irs(&date), "01/02/2021");
 /// ```
 ///
-/// // gx todo: support other locales
+/// Formats a `NaiveDate` as a string in `mm/dd/YYYY` format for IRS compliance.
+///
+/// # Examples
+///
+/// ```
+/// use chrono::NaiveDate;
+/// let date = NaiveDate::from_ymd_opt(2024, 5, 15).unwrap();
+/// let formatted = format_date_for_irs(&date);
+/// assert_eq!(formatted, "05/15/2024");
+/// ```
+pub fn format_date_for_irs(date: &NaiveDate) -> String {
 pub fn format_date_for_irs(date: &NaiveDate) -> String {
     let date = NaiveDate::from_ymd_opt(date.year(), date.month(), date.day()).unwrap();
     let date = date.format("%m/%d/%Y").to_string();
@@ -104,6 +134,7 @@ mod tests {
     }
 
     #[test]
+    /// Tests that `parse_date` correctly handles leading and trailing whitespace in the input string by ensuring trimmed and untrimmed inputs yield the same result.
     fn parse_date_trim() {
         let trimmed = parse_date("01/02/21");
         let spaced = parse_date(" 01/02/21 ");
@@ -111,6 +142,14 @@ mod tests {
     }
 
     #[test]
+    /// Tests that `format_date_for_irs` correctly formats a `NaiveDate` as `mm/dd/YYYY`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let date = NaiveDate::from_ymd_opt(2021, 1, 2).unwrap();
+    /// assert_eq!(format_date_for_irs(&date), "01/02/2021");
+    /// ```
     fn format_date() {
         let date = NaiveDate::from_ymd_opt(2021, 1, 2).unwrap();
         assert_eq!(format_date_for_irs(&date), "01/02/2021");


### PR DESCRIPTION
## Summary
- add doctest for `check_clipboard`
- make `parse_date` and `format_date_for_irs` public with examples
- add comprehensive unit tests for parsing and formatting

## Testing
- `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved and expanded documentation for key functions, including usage examples and clearer descriptions.
- **Tests**
  - Introduced unit tests to verify correct behavior and handling of various input scenarios for date parsing and formatting functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->